### PR TITLE
[BASE-1400] Weighted Load: Invalid config

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ Specific log messages:
 4. `Weighted load step "<STEP_ID>" timeout`
 
 ## Jar & Sources
-http://central.maven.org/maven2/com/github/emc-mongoose/mongoose-load-step-weighted/
+https://mvnrepository.com/artifact/com.github.emc-mongoose/mongoose-load-step-weighted

--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ Specific log messages:
 4. `Weighted load step "<STEP_ID>" timeout`
 
 ## Jar & Sources
-https://mvnrepository.com/artifact/com.github.emc-mongoose/mongoose-load-step-weighted
+https://mvnrepository.com/artifact/com.github.emc-mongoose/mongoose-load-step-weighted 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 description = "Mongoose is a high-load storage performance testing tool"
 group = "com.github.emc-mongoose"
-version = "4.2.10"
+version = "4.2.11"
 sourceCompatibility = 11
 targetCompatibility = 11
 

--- a/src/main/java/com/emc/mongoose/load/step/weighted/WeightedLoadStepLocal.java
+++ b/src/main/java/com/emc/mongoose/load/step/weighted/WeightedLoadStepLocal.java
@@ -131,7 +131,7 @@ public class WeightedLoadStepLocal
 
 				final DataInput dataInput = DataInput.instance(
 					dataInputConfig.stringVal("file"), dataInputConfig.stringVal("seed"), dataLayerSize,
-					dataLayerConfig.intVal("cache"), dataInputConfig.boolVal("heap")
+					dataLayerConfig.intVal("cache"), dataLayerConfig.boolVal("heap")
 				);
 
 				final int batchSize = loadConfig.intVal("batch-size");


### PR DESCRIPTION
**Start command/request**
Launch Mongoose with any kind of custom scenario.

**Expected behavior**
Scenario run.

**Observed behavior**
Failure for configuration mapping: Invalid value type @ heap, expected: "boolean", actual: "null".

```
2020-04-07T13:14:45,636 I StorageDriver single_task_executor_#1 Authentication type: none
2020-04-07T13:14:45,689 E WeightedLoadStepClient single_task_executor_#1 weighted_20200407.131445.560: failed to start the step slice "com.emc.mongoose.load.step.weighted.WeightedLoadStepLocal@58d65002"
CAUSE: com.github.akurilov.confuse.exceptions.InvalidValueTypeException: Invalid value type @ heap, expected: "boolean", actual: "null"
2020-04-07T13:14:45,691 I WeightedLoadStepClient single_task_executor_#1 weighted_20200407.131445.560: load step client started, additional nodes: []
2020-04-07T13:14:45,691 I fibers-executor-#2 Failed to fetch the
```

Jira: https://mongoose-issues.atlassian.net/browse/BASE-1400